### PR TITLE
replace system bit option by auto detection

### DIFF
--- a/installerGUI.py
+++ b/installerGUI.py
@@ -84,9 +84,6 @@ class installerWelcomeWindow(installerBaseWindow, welcomeDialog.Ui_Dialog):
         installerBaseWindow.__init__(self)
         self.setupUi(self.MainWindow)
         self.logoLabel.setPixmap(QtGui.QPixmap(_fromUtf8("images/tigernetLogo.png")))
-        self.osComboBox.addItem("64 bit")
-        self.osComboBox.addItem("32 bit")
-
         QtCore.QObject.connect(self.beginButton, QtCore.SIGNAL("clicked()"), self.next)
         QtCore.QObject.connect(self.cancelButton, QtCore.SIGNAL("clicked()"), self.cancel)
 

--- a/ui/welcomeDialog.py
+++ b/ui/welcomeDialog.py
@@ -36,9 +36,6 @@ class Ui_Dialog(object):
         self.logoLabel.setPixmap(QtGui.QPixmap(_fromUtf8("../images/tigernetLogo.png")))
         self.logoLabel.setScaledContents(True)
         self.logoLabel.setObjectName(_fromUtf8("logoLabel"))
-        self.osComboBox = QtGui.QComboBox(Dialog)
-        self.osComboBox.setGeometry(QtCore.QRect(280, 150, 81, 16))
-        self.osComboBox.setObjectName(_fromUtf8("osComboBox"))
         self.osLabel = QtGui.QLabel(Dialog)
         self.osLabel.setGeometry(QtCore.QRect(20, 150, 251, 16))
         self.osLabel.setObjectName(_fromUtf8("osLabel"))
@@ -76,7 +73,6 @@ class Ui_Dialog(object):
 
     def retranslateUi(self, Dialog):
         Dialog.setWindowTitle(_translate("Dialog", "WOIS Installation", None))
-        self.osLabel.setText(_translate("Dialog", "Choose your operating system (32 bit or 64 bit):", None))
         self.licenseLabel.setText(_translate("Dialog", "By beginning the installation you accept the license conditions for the TIGER-NET developed software, stated below. The other WOIS components might come with different license agreements which you will have to accept during the installation process. However, they are all classified as open-source.", None))
         self.cancelButton.setText(_translate("Dialog", "Cancel", None))
         self.licenseTextBrowser.setHtml(_translate("Dialog", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"

--- a/ui/welcomeDialog.ui
+++ b/ui/welcomeDialog.ui
@@ -36,29 +36,6 @@
     <bool>true</bool>
    </property>
   </widget>
-  <widget class="QComboBox" name="osComboBox">
-   <property name="geometry">
-    <rect>
-     <x>280</x>
-     <y>150</y>
-     <width>81</width>
-     <height>16</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QLabel" name="osLabel">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>150</y>
-     <width>251</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Choose your operating system (32 bit or 64 bit):</string>
-   </property>
-  </widget>
   <widget class="QLabel" name="licenseLabel">
    <property name="geometry">
     <rect>

--- a/woisInstaller.py
+++ b/woisInstaller.py
@@ -60,7 +60,8 @@ class woisInstaller():
 
         if res == NEXT:
             # select installation files for 32 or 64 bit install
-            if self.dialog.osComboBox.itemText(self.dialog.osComboBox.currentIndex()) == "32 bit":
+            installationsDirs = ['Installations_x32', 'Installations_x64']
+            if os.path.isdir(installationsDirs[0]):
                 is32bit = True
                 installationsDir = "Installations_x32"
                 osgeo4wInstall = os.path.join(installationsDir, "osgeo4w-setup.bat")
@@ -72,7 +73,7 @@ class woisInstaller():
                 mapwindowInstall = os.path.join(installationsDir, "MapWindowx86Full-v488SR-installer.exe")
                 mwswatInstall = os.path.join(installationsDir, "MWSWAT2009.exe")
                 swateditorInstall = "MWSWAT additional software\\SwatEditor_Install\\Setup.exe"
-            else:
+            elif os.path.isdir(installationsDirs[1]):
                 is32bit = False
                 installationsDir = "Installations_x64"
                 osgeo4wInstall = os.path.join(installationsDir, "osgeo4w-setup.bat")
@@ -84,6 +85,8 @@ class woisInstaller():
                 mapwindowInstall = os.path.join(installationsDir, "MapWindowx86Full-v488SR-installer.exe")
                 mwswatInstall = os.path.join(installationsDir, "MWSWAT2009.exe")
                 swateditorInstall = "MWSWAT additional software\\SwatEditor_Install\\Setup.exe"
+            else:
+                raise RuntimeError('Neither 32 bit nor 64 bit instalations directory exists. Package incomplete.')
             # select default installation directories for 32 or 64 bit install
             if is32bit:
                 osgeo4wDefaultDir = "C:\\OSGeo4W"

--- a/woisInstaller.py
+++ b/woisInstaller.py
@@ -63,7 +63,7 @@ class woisInstaller():
             installationsDirs = ['Installations_x32', 'Installations_x64']
             if os.path.isdir(installationsDirs[0]):
                 is32bit = True
-                installationsDir = "Installations_x32"
+                installationsDir = installationsDirs[0]
                 osgeo4wInstall = os.path.join(installationsDir, "osgeo4w-setup.bat")
                 beamInstall = os.path.join(installationsDir, "beam_5.0_win32_installer.exe")
                 snapInstall = os.path.join(installationsDir, "esa-snap_sentinel_windows_5_0.exe")
@@ -75,7 +75,7 @@ class woisInstaller():
                 swateditorInstall = "MWSWAT additional software\\SwatEditor_Install\\Setup.exe"
             elif os.path.isdir(installationsDirs[1]):
                 is32bit = False
-                installationsDir = "Installations_x64"
+                installationsDir = installationsDirs[1]
                 osgeo4wInstall = os.path.join(installationsDir, "osgeo4w-setup.bat")
                 beamInstall = os.path.join(installationsDir, "beam_5.0_win64_installer.exe")
                 snapInstall = os.path.join(installationsDir, "esa-snap_sentinel_windows-x64_5_0.exe")
@@ -86,7 +86,8 @@ class woisInstaller():
                 mwswatInstall = os.path.join(installationsDir, "MWSWAT2009.exe")
                 swateditorInstall = "MWSWAT additional software\\SwatEditor_Install\\Setup.exe"
             else:
-                raise RuntimeError('Neither 32 bit nor 64 bit instalations directory exists. Package incomplete.')
+                self.util.error_exit('Neither 32 bit nor 64 bit instalations directory exists. Package incomplete.')
+                return
             # select default installation directories for 32 or 64 bit install
             if is32bit:
                 osgeo4wDefaultDir = "C:\\OSGeo4W"
@@ -520,26 +521,26 @@ class Utilities(QtCore.QObject):
         except:
             pass
 
+    def error_exit(self, msg):
+        msgBox = QtGui.QMessageBox()
+        msgBox.setText(msg)
+        msgBox.exec_()
+        self.finished.emit()
+
     def copyFiles(self, srcPath, dstPath, checkDstParentExists=True):
 
         # a simple check to see if we are copying to the right directory by making sure that
         # its parent exists
         if checkDstParentExists:
             if not os.path.isdir(os.path.dirname(dstPath)):
-                msgBox = QtGui.QMessageBox()
-                msgBox.setText("Could not find the destination directory!\n\n No files were copied.")
-                msgBox.exec_()
-                self.finished.emit()
+                self.error_exit("Could not find the destination directory!\n\n No files were copied.")
                 return
 
         # checkWritePremissions alsoe creates the directory if it doesn't exist yet
         if not self.checkWritePermissions(dstPath):
-            msgBox = QtGui.QMessageBox()
-            msgBox.setText("You do not have permissions to write to destination directory!\n\n No files were copied.\n\n"+
-                           "Re-run the installer with administrator privileges or manually copy files from "+srcPath+
-                           " to "+dstPath+" after the installation process is over.")
-            msgBox.exec_()
-            self.finished.emit()
+            self.error_exit("You do not have permissions to write to destination directory!\n\n No files were copied.\n\n"+
+                            "Re-run the installer with administrator privileges or manually copy files from "+srcPath+
+                            " to "+dstPath+" after the installation process is over.")
             return
 
         # for directories copy the whole directory recursively
@@ -557,20 +558,14 @@ class Utilities(QtCore.QObject):
 
     def unzipArchive(self, archivePath, dstPath):
         if not os.path.isfile(archivePath):
-            msgBox = QtGui.QMessageBox()
-            msgBox.setText("Could not find the archive!\n\n No files were extracted.")
-            msgBox.exec_()
-            self.finished.emit()
+            self.error_exit("Could not find the archive!\n\n No files were extracted.")
             return
 
         # checkWritePremissions also creates the directory if it doesn't exist yet
         if not self.checkWritePermissions(dstPath):
-            msgBox = QtGui.QMessageBox()
-            msgBox.setText("You do not have permissions to write to destination directory!\n\n No files were copied.\n\n"+
+            self.error_exit("You do not have permissions to write to destination directory!\n\n No files were copied.\n\n"+
                            "Re-run the installer with administrator privileges or manually unzip files from "+archivePath+
                            " to "+dstPath+" after the installation process is over.")
-            msgBox.exec_()
-            self.finished.emit()
             return
 
         archive = ZipFile(archivePath)


### PR DESCRIPTION
Automatically detect whether the installer is for 32 bit or 64 bit by the existence of the folders "Installations_x32" and "Installations_x64", respectively. Remove drop-down option in welcome dialogue.

The option was obsolete because we distribute the two packages (32 bit and 64 bit) separately to reduce donwload size. Thereby, the user chooses the version already at download.

See also discussion at https://github.com/TIGER-NET/WOIS_Installer/commit/1f77901369df0b74d80679bd7af7adb0802571b8#commitcomment-19282307 .

We can merge this or keep it as separate branch. Preferences?
